### PR TITLE
Migrate azure service bus trigger to slbeta6

### DIFF
--- a/asyncapi/asb/Ballerina.toml
+++ b/asyncapi/asb/Ballerina.toml
@@ -1,20 +1,20 @@
 [package]
 org = "ballerinax"
 name = "trigger.asb"
-version = "0.2.0"
+version = "0.3.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/asyncapi-triggers"
-distribution = "slbeta5"
+distribution = "slbeta6"
 
 [build-options]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../../native/asb/build/libs/asb-1.0.0-all.jar"
+path = "../../native/asb/build/libs/asb-0.3.0-all.jar"
 groupId = "org.ballerinax"
 artifactId = "asb"
 module = "asb" 
-version = "1.0.0"
+version = "0.3.0"

--- a/asyncapi/asb/Dependencies.toml
+++ b/asyncapi/asb/Dependencies.toml
@@ -37,7 +37,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "trigger.asb"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/asyncapi/asb/Package.md
+++ b/asyncapi/asb/Package.md
@@ -9,7 +9,7 @@ This package provides the capability to access Microsoft Azure Service Bus messa
 
 |                            | Version               |
 |----------------------------|-----------------------|
-| Ballerina Language         | Swan Lake Beta5       |
+| Ballerina Language         | Swan Lake Beta6       |
 | Azure Service Bus SDK      | 3.5.1                 |
 
 ## Report issues

--- a/native/gradle.properties
+++ b/native/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.caching=true
 log4j_version=1.2.17
-ballerinaLangVersion=2.0.0-beta.5.2
+ballerinaLangVersion=2.0.0-beta.6
 
 // Azure service bus trigger
 asb_trigger_group=io.ballerinax.asb
-asb_trigger_version=1.0.0
+asb_trigger_version=0.3.0
 asb_sdk_version=3.5.1


### PR DESCRIPTION
## Purpose
> 
Migrate azure service bus trigger to SLBeta6

Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/214

## Goals
> Migrate azure service bus trigger to SLBeta6

## Approach
> 
Update Ballerina lang version to 2.0.0-beta.6

## Release note
> Migrate azure service bus trigger to SLBeta6

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > None

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Migrations (if applicable)
> Migrate to Ballerina SLBeta6

## Test environment
> 
Ballerina Version: SLBeta6
Operating System: Ubuntu 20.04
Java SDK: 11