### PR TITLE
Remove Ballerina runtime dependency from native jar

### DIFF
--- a/asyncapi/asb/Ballerina.toml
+++ b/asyncapi/asb/Ballerina.toml
@@ -1,20 +1,20 @@
 [package]
 org = "ballerinax"
 name = "trigger.asb"
-version = "0.3.2"
+version = "0.3.3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
 icon = "docs/icon.png"
 repository = "https://github.com/ballerina-platform/asyncapi-triggers"
-distribution = "slbeta6"
+distribution = "2201.0.0"
 
 [build-options]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../../native/asb/build/libs/asb-0.3.1-all.jar"
+path = "../../native/asb/build/libs/asb-0.3.3.jar"
 groupId = "org.ballerinax"
 artifactId = "asb"
 module = "asb" 
-version = "0.3.1"
+version = "0.3.3"

--- a/asyncapi/asb/Dependencies.toml
+++ b/asyncapi/asb/Dependencies.toml
@@ -17,7 +17,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -37,7 +37,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "trigger.asb"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/asyncapi/asb/Package.md
+++ b/asyncapi/asb/Package.md
@@ -7,10 +7,10 @@ This package provides the capability to access Microsoft Azure Service Bus messa
 
 ### Compatibility
 
-|                            | Version               |
-|----------------------------|-----------------------|
-| Ballerina Language         | Swan Lake Beta6       |
-| Azure Service Bus SDK      | 3.5.1                 |
+|                            | Version                      |
+|----------------------------|------------------------------|
+| Ballerina Language         | Ballerina Swan Lake 2201.0.0 |
+| Azure Service Bus SDK      | 3.5.1                        |
 
 ## Report issues
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ githubJohnrengelmanShadowVersion=5.2.0
 underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0
 checkstyleToolVersion=7.8.2
-ballerinaLangVersion=2.0.0-beta.6
+ballerinaLangVersion=2201.0.0
 
 // SFDC trigger
 sfdc_trigger_group=io.ballerina.sfdc
@@ -17,5 +17,5 @@ sfdc_trigger_version=0.3.0
 
 // Azure service bus trigger
 asb_trigger_group=io.ballerinax.asb
-asb_trigger_version=0.3.1
+asb_trigger_version=0.3.3
 asb_sdk_version=3.5.1

--- a/native/asb/build.gradle
+++ b/native/asb/build.gradle
@@ -6,6 +6,12 @@ plugins {
 group project.asb_trigger_group
 version project.asb_trigger_version
 
+configurations {
+    dist {
+        transitive true
+    }
+}
+
 repositories {
     mavenCentral()
 
@@ -20,10 +26,20 @@ repositories {
 
 dependencies {
     implementation group: 'com.microsoft.azure', name: 'azure-servicebus', version: project.asb_sdk_version
+    dist group: 'com.microsoft.azure', name: 'azure-servicebus', version: project.asb_sdk_version
     implementation group: 'org.slf4j', name: 'slf4j-api', version: project.slf4jVersion
     compile group: 'org.ballerinalang', name: 'ballerina-lang', version: project.ballerinaLangVersion
     compile(group: 'org.ballerinalang', name: 'ballerina-runtime', version: project.ballerinaLangVersion) {
         transitive = false
+    }
+}
+
+jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn configurations.dist
+    from { configurations.dist.collect { it.isDirectory() ? it : zipTree(it) } } {
+        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'io/netty/**', 'com/google/gson/**', 
+        'org/slf4j/**', 'org/apache/commons/lang3/**' 
     }
 }
 


### PR DESCRIPTION
## Purpose
> 
Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/318

## Goals
> 
Remove Ballerina runtime dependency from native jar dependency
Bump version to 2201.0.0

## Approach
> 
Define a new configuration and include only the necessary dependencies

## Release note
> Remove Ballerina runtime dependency from native jar dependency

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> 
Ballerina Version: 2201.0.0
Operating System: Ubuntu 20.04
Java SDK: 11
 