### PR TITLE
Fix sha256 signature not available issue

### DIFF
--- a/asyncapi/github/Dependencies.toml
+++ b/asyncapi/github/Dependencies.toml
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cloud"
-version = "2.1.4"
+version = "2.1.5"
 modules = [
 	{org = "ballerina", packageName = "cloud", moduleName = "cloud"}
 ]


### PR DESCRIPTION
## Purpose
Some specific events triggered by github event api doesn't include the sha256 encoded secret. Hence we need to conditionally check and validate. This PR adds the support to events without sha256 encoded secrets.

Issue - https://github.com/wso2-enterprise/choreo/issues/12891

## Goals
Support github events withouth sha256 encoded secret

