### PR TITLE
[migrate-2201.2.1] Remove invalid link for github trigger samples

### DIFF
--- a/asyncapi/github/Module.md
+++ b/asyncapi/github/Module.md
@@ -101,5 +101,3 @@ Use `bal run` command to compile and run the Ballerina program.
 - Select the list of events you need to subscribe to and click on Add webhook.
 
 This will add a subscription to github event api and the ballerina service functions will be triggerred once an event is fired.
-
-**[You can find a list of samples here](https://github.com/ballerina-platform/module-ballerinax-github/tree/master/github/samples/listener)**


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/15990
- Remove invalid link for github trigger samples

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
