### PR TITLE
Add multi service attachment support for ASB listener

### DIFF
--- a/asyncapi/asb/data_types.bal
+++ b/asyncapi/asb/data_types.bal
@@ -156,3 +156,16 @@ public type ErrorContext record {
     string errorSource;
     string reason;
 };
+
+public type ASBServiceConfig record {|
+    string queueName?;
+    boolean peekLockModeEnabled = false;
+    string topicName?;
+    string subscriptionName?;
+    int maxConcurrency = 1;
+    int prefetchCount =  0;
+    int maxAutoLockRenewDuration = 300;
+    string logLevel = ERROR;
+|};
+
+public annotation ASBServiceConfig ServiceConfig on service, class;

--- a/asyncapi/asb/data_types.bal
+++ b/asyncapi/asb/data_types.bal
@@ -103,54 +103,11 @@ public type Error AsbError;
 // Default values
 const string EMPTY_STRING = "";
 
-# This record holds the configuration details of a topic and its associated subscription in Azure Service Bus
-#
-# + topicName - A string field that holds the name of the topic  
-# + subscriptionName - A string field that holds the name of the subscription associated with the topic
-@display {label: "Topic/Subscriptions Configurations"}
-public type TopicSubsConfig record {
-    @display {label: "Topic Name"}
-    string topicName;
-    @display {label: "Subscription Name"}
-    string subscriptionName;
-};
-
-# This record holds the configuration details of a queue in Azure Service Bus
-#
-# + queueName - A string field that holds the name of the queue
-@display {label: "Queue Configurations"}
-public type QueueConfig record {
-    @display {label: "Queue Name"}
-    string queueName;
-};
-
 # Azure service bus listener configuration.
 public type ListenerConfig record {
     # The connection string of Azure service bus
     @display {label: "Connection String", "description": "The connection string of Azure service bus"}
     string connectionString;
-    # Name or path of the entity (e.g : Queue name, Subscription path)
-    @display {label: "Entity Configuration"}
-    TopicSubsConfig|QueueConfig entityConfig;
-    # Receive mode as PEEKLOCK or RECEIVEANDDELETE (default : PEEKLOCK)
-    @display {label: "Receive Mode", "description": "Receive mode as PEEKLOCK or RECEIVEANDDELETE (default : PEEKLOCK)"}
-    ReceiveMode receiveMode = PEEK_LOCK;
-    # The maximum number (default 1) of concurrent calls (i.e., the maximum number of messages that can be processed at the same time)
-    @display {label: "Number of maximum concurrent calls", "description": 
-    "The maximum number of messages that can be processed at the same time"}
-    int maxConcurrentCalls = 1;
-    # The prefetch count (default 0), representing the number of messages that the listener should receive and buffer
-    @display {label: "Prefetch Count", "description": "The number of messages that the listener should receive and buffer"}
-    int prefetchCount = 0;
-    # The property that controls the maximum duration for which a message lock can be automatically renewed. The lock on 
-    # a message is used to prevent other consumers from processing the same message while it is being processed by the 
-    # current consumer. When the lock is about to expire, it can be automatically renewed if the maxAutoLockRenewDuration 
-    # has not been reached. This property is useful in scenarios where processing a message may take longer than the lock 
-    # duration, to prevent the message from becoming available to other consumers before it is finished processing. 
-    # The value of this property is specified in seconds. Setting Duration#ZERO disables auto-renewal(default)
-    @display {label: "Max Auto Lock Renew Duration in seconds", "description": 
-    "The maximum duration(in seconds) for which a message lock can be automatically renewed"}
-    int maxAutoLockRenewDuration = 0;
 };
 
 # Represents Custom configurations for the ASB connector

--- a/native/asb/src/main/java/io/ballerinax/asb/ASBResourceCallback.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/ASBResourceCallback.java
@@ -18,6 +18,7 @@
 
 package io.ballerinax.asb;
 
+import java.util.concurrent.CountDownLatch;
 import io.ballerina.runtime.api.async.Callback;
 import io.ballerina.runtime.api.values.BError;
 
@@ -25,13 +26,24 @@ import io.ballerina.runtime.api.values.BError;
  * Handles the Azure service bus resource callback.
  */
 public class ASBResourceCallback implements Callback {
+
+    private final CountDownLatch countDownLatch;
+
+    ASBResourceCallback (CountDownLatch countDownLatch) {
+        this.countDownLatch = countDownLatch;
+    }
+
     @Override
     public void notifySuccess(Object obj) {
-        // do nothing
+        if (obj instanceof BError) {
+            ((BError) obj).printStackTrace();
+        }
+        countDownLatch.countDown();
     }
 
     @Override
     public void notifyFailure(BError error) {
-        // do nothing
+        error.printStackTrace();
+        countDownLatch.countDown();
     }
 }

--- a/native/asb/src/main/java/io/ballerinax/asb/MessageDispatcher.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/MessageDispatcher.java
@@ -97,11 +97,7 @@ public class MessageDispatcher {
     }
 
     private ServiceBusProcessorClient createMessageProcessor(ServiceBusClientBuilder sharedClientBuilder) {
-        String queueName = ASBUtils.getServiceConfigStringValue(service, ASBConstants.QUEUE_NAME_CONFIG_KEY); // TODO
-                                                                                                              // set
-                                                                                                              // defaults
-                                                                                                              // if not
-                                                                                                              // set
+        String queueName = ASBUtils.getServiceConfigStringValue(service, ASBConstants.QUEUE_NAME_CONFIG_KEY); 
         String topicName = ASBUtils.getServiceConfigStringValue(service, ASBConstants.TOPIC_NAME_CONFIG_KEY);
         String subscriptionName = ASBUtils.getServiceConfigStringValue(service,
                 ASBConstants.SUBSCRIPTION_NAME_CONFIG_KEY);

--- a/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
@@ -133,6 +133,7 @@ public class MessageListener {
                     .get(service).getProcessorClient().getIdentifier() + " upon detaching service");
         }
         services.remove(service);
+        dispatcherSet.remove(service);
         return null;
     }
 
@@ -150,6 +151,8 @@ public class MessageListener {
             for (BObject service : services) {
                 stopMessageDispatch(service);
             }
+            services.clear();
+            dispatcherSet.clear();
         }
         return null;
     }

--- a/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
@@ -16,229 +16,167 @@
  * under the License.
  */
 
- package io.ballerinax.asb.listener;
+package io.ballerinax.asb.listener;
 
- import java.time.Duration;
- import java.util.ArrayList;
- import java.util.HashMap;
- import java.util.List;
- import java.util.Map;
- import java.util.Objects;
- import java.util.concurrent.ExecutorService;
- import java.util.concurrent.Executors;
- import java.util.concurrent.Future;
- 
- import org.apache.log4j.Level;
- import org.apache.log4j.Logger;
- 
- import com.azure.messaging.servicebus.ServiceBusClientBuilder;
- import com.azure.messaging.servicebus.ServiceBusClientBuilder.ServiceBusProcessorClientBuilder;
- import com.azure.messaging.servicebus.ServiceBusException;
- import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
- 
- import io.ballerina.runtime.api.Environment;
- import io.ballerina.runtime.api.Runtime;
- import io.ballerina.runtime.api.values.BObject;
- import io.ballerinax.asb.MessageDispatcher;
- import io.ballerinax.asb.util.ASBConstants;
- import io.ballerinax.asb.util.ASBUtils;
- 
- /**
-  * Listens to incoming messages from Azure Service Bus.
-  */
- public class MessageListener {
-     private final Logger log = Logger.getLogger(MessageListener.class);
- 
-     private Runtime runtime;
-     private ArrayList<BObject> services = new ArrayList<>();
-     private Map<BObject, MessageDispatcher> dispatcherSet = new HashMap<BObject, MessageDispatcher>();
-     private List<Future<?>> futures = new ArrayList<>();
-     private BObject caller;
-     private Level logLevel;
-     private ServiceBusProcessorClientBuilder clientBuilder;
-     private boolean started = false;
- 
-     /**
-      * Initialize Azure Service Bus listener.
-      *
-      * @param connectionString Azure service bus connection string.
-      * @param entityPath       Entity path (QueueName or SubscriptionPath).
-      * @param receiveMode      Receive Mode as PeekLock or Receive&Delete.
-      * @throws ServiceBusException  on failure initiating IMessage Receiver in Azure
-      *                              Service Bus instance.
-      * @throws InterruptedException on failure initiating IMessage Receiver due to
-      *                              thread interruption.
-      */
-     public MessageListener(String connectionString, String queueName, String topicName, String subscriptionName,
-             String receiveMode, String logLevel, int maxConcurrentCalls, int prefetchCount,
-             int maxAutoLockRenewDuration)
-             throws ServiceBusException, InterruptedException {
-         this.logLevel = Level.toLevel(logLevel, Level.DEBUG);
-         log.setLevel(this.logLevel);
-         if (log.isDebugEnabled()) {
-         log.debug(
-                 "Initializing message listener with receiveMode " + receiveMode + ", maxConcurrentCalls- "
-                         + maxConcurrentCalls + ", prefetchCount - " + prefetchCount
-                         + ", maxAutoLockRenewDuration(seconds) - " + maxAutoLockRenewDuration);
-         }
- 
-         this.clientBuilder = new ServiceBusClientBuilder()
-                 .connectionString(connectionString)
-                 .processor()
-                 .maxConcurrentCalls(maxConcurrentCalls)
-                 .disableAutoComplete()
-                 .prefetchCount(prefetchCount);
-         if (!queueName.isEmpty()) {
-             if (Objects.equals(receiveMode, ASBConstants.RECEIVE_AND_DELETE)) {
-                 this.clientBuilder = this.clientBuilder
-                         .receiveMode(ServiceBusReceiveMode.RECEIVE_AND_DELETE)
-                         .queueName(queueName);
- 
-             } else {
-                 this.clientBuilder = this.clientBuilder
-                         .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
-                         .queueName(queueName)
-                         .maxAutoLockRenewDuration(Duration.ofSeconds(maxAutoLockRenewDuration));
-             }
-         } else if (!subscriptionName.isEmpty() && !topicName.isEmpty()) {
-             if (Objects.equals(receiveMode, ASBConstants.RECEIVE_AND_DELETE)) {
-                 this.clientBuilder = this.clientBuilder
-                         .receiveMode(ServiceBusReceiveMode.RECEIVE_AND_DELETE)
-                         .topicName(topicName)
-                         .subscriptionName(subscriptionName);
- 
-             } else {
-                 this.clientBuilder = this.clientBuilder
-                         .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
-                         .topicName(topicName)
-                         .subscriptionName(subscriptionName)
-                         .maxAutoLockRenewDuration(Duration.ofSeconds(maxAutoLockRenewDuration));
-             }
-         }
-     }
- 
-     public void externalInit(Environment environment, BObject listenerBObject, BObject caller) {
-         this.caller = caller;
-     }
- 
-     /**
-      * Attaches the service to the Asb listener endpoint.
-      *
-      * @param environment     Ballerina runtime.
-      * @param listenerBObject Ballerina listener object..
-      * @param service         Ballerina service instance.
-      * @return An error if failed to create IMessageReceiver connection instance.
-      */
-     public Object registerListener(Environment environment, BObject listenerBObject, BObject service) {
-         runtime = environment.getRuntime();
-         if (service == null) {
-             throw new IllegalArgumentException("Service object is null");
-         }
-         if (!services.contains(service)) {
-             services.add(service);
-         }
-         return null;
-     }
- 
-     /**
-      * Starts consuming the messages on all the attached services.
-      *
-      * @param environment     Ballerina runtime.
-      * @param listenerBObject Ballerina listener object
-      * @return An error if failed to start the listener.
-      */
-     public Object start(Environment environment, BObject listenerBObject) {
-         runtime = environment.getRuntime();
-         if (services.isEmpty()) {
-             return ASBUtils.createErrorValue("Error in starting receiving messages");
-         }
-         ExecutorService executor = Executors.newFixedThreadPool(services.size());
-         futures = new ArrayList<>();
-         for (BObject service : services) {
-             MessageDispatcher messageDispatcher = new MessageDispatcher(service, this.caller, runtime, clientBuilder, logLevel);
-             Future<?> future = executor.submit(() -> {
-                 try {
-                     messageDispatcher.receiveMessages(listenerBObject);
-                 } catch (Exception e) {
-                     return ASBUtils.createErrorValue("Error in starting receiving messages", e);
-                 }
-                 return null;
-             });
-             futures.add(future);
-             dispatcherSet.put(service, messageDispatcher);
-         }
-         started = true;
-         return null;
- 
-     }
- 
-     /**
-      * Stops consuming messages and detaches the service from the Asb Listener
-      * endpoint.
-      *
-      * @param listenerBObject Ballerina listener object..
-      * @param service         Ballerina service instance.
-      * @return An error if failed detaching the service.
-      */
-     public Object detach(BObject listenerBObject, BObject service) {
-         services.remove(service);
-         return null;
-     }
- 
-     /**
-      * Stops consuming messages through all consumer services by terminating the
-      * connection.
-      *
-      * @param listenerBObject Ballerina listener object.
-      * @return An error if listener fails to stop.
-      */
-     public Object stop(BObject listenerBObject) {
-         if (!started) {
-             return ASBUtils.createErrorValue("Listener has not properly started.");
-         } else {
-             for (Map.Entry<BObject, MessageDispatcher> entry : dispatcherSet.entrySet()) {
-                 entry.getValue().getProcessorClient().close();
-             }
-             try {
-                 for (Future<?> future : futures) {
-                     future.cancel(true);
-                 }
-                 Thread.currentThread().checkAccess();
-                 Thread.currentThread().interrupt();
-             } catch (Exception e) {
-                 return ASBUtils.createErrorValue("Error occurred while stopping the service", e);
-             }
-         }
-         return null;
-     }
- 
-     /**
-      * Stops consuming messages through all the consumer services and terminates the
-      * connection with server.
-      *
-      * @param listenerBObject Ballerina listener object.
-      * @return An error if listener fails to abort the connection.
-      */
-     public Object abortConnection(BObject listenerBObject) {
-         if (clientBuilder == null || !started) {
-             return ASBUtils.createErrorValue("clientBuilder is not properly initialized.");
-         } else {
-             try {
-                 for (Map.Entry<BObject, MessageDispatcher> entry : dispatcherSet.entrySet()) {
-                     entry.getValue().getProcessorClient().stop();
-                 }
-                 for (Future<?> future : futures) {
-                     future.cancel(true);
-                 }
-                 if (log.isDebugEnabled()) {
-                    log.debug("Consumer service aborted");
-                 }
-                 System.exit(0);
-             } catch (ServiceBusException e) {
-                 return ASBUtils.createErrorValue("Error occurred while stopping the service");
-             }
-         }
-         return null;
-     }
- }
- 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.Runtime;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerinax.asb.MessageDispatcher;
+import io.ballerinax.asb.util.ASBUtils;
+
+/**
+ * ASB message listener representation binding it to a Ballerina service.
+ */
+public class MessageListener {
+    private final Logger log = Logger.getLogger(MessageListener.class);
+
+    private Runtime runtime;
+    private ArrayList<BObject> services = new ArrayList<>();
+    private Map<BObject, MessageDispatcher> dispatcherSet = new HashMap<BObject, MessageDispatcher>();
+    private BObject caller;
+    private ServiceBusClientBuilder sharedConnectionBuilder;
+    private boolean started = false;
+
+    /**
+     * Initializes Azure Service Bus listener. This creates a connection to the pointed
+     * Azure Service Bus. Actual listeners will get created with the information
+     * of attached services.
+     *
+     * @param connectionString Azure service bus connection string.
+     */
+    public MessageListener(String connectionString, String logLevel) {
+        log.setLevel(Level.toLevel(logLevel, Level.ERROR));
+        this.sharedConnectionBuilder = new ServiceBusClientBuilder().connectionString(connectionString);
+    }
+
+    /**
+     * Attaches Caller object to the listener. 
+     * 
+     * @param caller object represeting Ballerina Caller 
+     */
+    public void externalInit(Environment environment, BObject caller) {
+        this.caller = caller;
+    }
+
+    /**
+     * Attaches the service to the ASB listener endpoint. Here, a new ASB message processor client 
+     * is created internally with the message dispatcher, but not started.
+     *
+     * @param environment     Ballerina runtime
+     * @param listenerBObject Ballerina listener object
+     * @param service         Ballerina service instance
+     * @return An error if failed to create IMessageReceiver connection instance
+     */
+    public Object attach(Environment environment, BObject listenerBObject, BObject service) {
+        try {
+            runtime = environment.getRuntime();
+            if (service == null) {
+                throw new IllegalArgumentException("Service object is null. Cannot attach to the listener");
+            }
+            if (!services.contains(service)) {
+                // We only create the dispatcher object here, but not start
+                MessageDispatcher msgDispatcher = new MessageDispatcher(runtime, service, caller,
+                        sharedConnectionBuilder);
+                services.add(service);
+                dispatcherSet.put(service, msgDispatcher);
+            } else {
+                throw new IllegalStateException("Service already attached.");
+            }
+            return null;
+        } catch (IllegalStateException | IllegalArgumentException | NullPointerException ex) {
+            return ASBUtils.createErrorValue("Error when attaching service to the listener and stating processor.", ex);
+        }
+    }
+
+    /**
+     * Starts consuming the messages on all the attached 
+     * services if not already started.
+     *
+     * @param environment     Ballerina runtime
+     * @param listenerBObject Ballerina listener object
+     * @return An error if failed to start the listener
+     */
+    public Object start(Environment environment, BObject listenerBObject) {
+        runtime = environment.getRuntime();
+        if (services.isEmpty()) {
+            return ASBUtils.createErrorValue("No attached services found");
+        }
+        for (BObject service : services) {
+            try {
+                startMessageDispatch(service);
+            } catch (Exception e) {
+                return ASBUtils.createErrorValue("Error while starting message listening for service = ", e);
+            }
+        }
+        started = true;
+        return null;
+    }
+
+    /**
+     * Stops consuming messages and detaches the service from the ASB Listener
+     * endpoint.
+     *
+     * @param listenerBObject Ballerina listener object.
+     * @param service         Ballerina service instance.
+     * @return An error if failed detaching the service.
+     */
+    public Object detach(Environment environment, BObject listenerBObject, BObject service) {
+        try {
+            stopMessageDispatch(service);
+        } catch (Exception e) {
+            return ASBUtils.createErrorValue("Error while closing the processor client id = " + dispatcherSet
+                    .get(service).getProcessorClient().getIdentifier() + " upon detaching service");
+        }
+        services.remove(service);
+        return null;
+    }
+
+    /**
+     * Stops consuming messages through all consumer services by terminating the
+     * listeners and connection.
+     *
+     * @param listenerBObject Ballerina listener object.
+     * @return An error if listener fails to stop.
+     */
+    public Object stop(Environment environment, BObject listenerBObject) {
+        if (!started) {
+            return ASBUtils.createErrorValue("Listener has not started.");
+        } else {
+            for (BObject service : services) {
+                stopMessageDispatch(service);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Stops consuming messages through all the consumer services and terminates the
+     * listeners and the connection with server.
+     *
+     * @param listenerBObject Ballerina listener object.
+     * @return An error if listener fails to abort the connection.
+     */
+    public Object forceStop(Environment environment, BObject listenerBObject) {
+        stop(environment, listenerBObject);
+        return null;
+    }
+
+    private void stopMessageDispatch(BObject service) {
+        MessageDispatcher msgDispatcher = dispatcherSet.get(service);
+        msgDispatcher.stopListeningAndDispatching();
+    }
+
+    private void startMessageDispatch(BObject service) {
+        MessageDispatcher msgDispatcher = dispatcherSet.get(service);
+        if (!msgDispatcher.isRunning()) {
+            msgDispatcher.startListeningAndDispatching();
+        }
+    }
+}

--- a/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/listener/MessageListener.java
@@ -61,7 +61,7 @@ public class MessageListener {
      * 
      * @param caller object represeting Ballerina Caller 
      */
-    public void externalInit(Environment environment, BObject caller) {
+    public void externalInit(BObject caller) {
         this.caller = caller;
     }
 
@@ -99,12 +99,10 @@ public class MessageListener {
      * Starts consuming the messages on all the attached 
      * services if not already started.
      *
-     * @param environment     Ballerina runtime
      * @param listenerBObject Ballerina listener object
      * @return An error if failed to start the listener
      */
-    public Object start(Environment environment, BObject listenerBObject) {
-        runtime = environment.getRuntime();
+    public Object start(BObject listenerBObject) {
         if (services.isEmpty()) {
             return ASBUtils.createErrorValue("No attached services found");
         }
@@ -127,7 +125,7 @@ public class MessageListener {
      * @param service         Ballerina service instance.
      * @return An error if failed detaching the service.
      */
-    public Object detach(Environment environment, BObject listenerBObject, BObject service) {
+    public Object detach(BObject listenerBObject, BObject service) {
         try {
             stopMessageDispatch(service);
         } catch (Exception e) {
@@ -145,7 +143,7 @@ public class MessageListener {
      * @param listenerBObject Ballerina listener object.
      * @return An error if listener fails to stop.
      */
-    public Object stop(Environment environment, BObject listenerBObject) {
+    public Object stop(BObject listenerBObject) {
         if (!started) {
             return ASBUtils.createErrorValue("Listener has not started.");
         } else {
@@ -163,8 +161,8 @@ public class MessageListener {
      * @param listenerBObject Ballerina listener object.
      * @return An error if listener fails to abort the connection.
      */
-    public Object forceStop(Environment environment, BObject listenerBObject) {
-        stop(environment, listenerBObject);
+    public Object forceStop(BObject listenerBObject) {
+        stop(listenerBObject);
         return null;
     }
 

--- a/native/asb/src/main/java/io/ballerinax/asb/util/ASBConstants.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/util/ASBConstants.java
@@ -36,7 +36,7 @@ public class ASBConstants {
     public static final String INT_CONTENT_ERROR = "Error while retrieving the int content of the message. ";
     public static final String FLOAT_CONTENT_ERROR = "Error while retrieving the float content of the message. ";
     // Message receive modes
-    public static final String PEEK_LOCK = "PEEKLOCK";
+    //public static final String PEEK_LOCK = "PEEKLOCK";
     public static final String RECEIVE_AND_DELETE = "RECEIVEANDDELETE";
     // listener constant fields
     public static final String CONSUMER_SERVICES = "consumer_services";
@@ -47,4 +47,19 @@ public class ASBConstants {
     public static final String DISPATCH_ERROR = "Error occurred while dispatching the message. ";
     public static final BString QUEUE_NAME = StringUtils.fromString("entity");
     public static final String UNCHECKED = "unchecked";
+
+    //ASB listener and service config fields
+    public static final String SERVICE_CONFIG = "ServiceConfig";
+    public static final BString PEEK_LOCK_ENABLE_CONFIG_KEY = StringUtils.fromString("peekLockModeEnabled");
+    public static final String QUEUE_NAME_CONFIG_KEY = "queueName";
+    public static final String TOPIC_NAME_CONFIG_KEY = "topicName";
+    public static final String SUBSCRIPTION_NAME_CONFIG_KEY = "subscriptionName";
+    public static final String MAX_CONCURRENCY_CONFIG_KEY = "maxConcurrency";
+    public static final String MSG_PREFETCH_COUNT_CONFIG_KEY = "prefetchCount";
+    public static final String LOCK_RENEW_DURATION_CONFIG_KEY = "maxAutoLockRenewDuration";
+    public static final String LOG_LEVEL_CONGIG_KEY = "logLevel";
+    public static final String EMPTY_STRING = "";
+    public static final int MAX_CONCURRENCY_DEFAULT = 1;
+    public static final int LOCK_RENEW_DURATION_DEFAULT = 300;
+    public static final int MSG_PREFETCH_COUNT_DEFAULT = 0;
 }

--- a/native/asb/src/main/java/io/ballerinax/asb/util/ASBUtils.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/util/ASBUtils.java
@@ -115,7 +115,7 @@ public class ASBUtils {
      * 
      * @param service Service instance
      * @param key Key of the configuration
-     * @return String value of the given config key, or null if not found
+     * @return String value of the given config key, or empty string if not found
      */
     public static String getServiceConfigStringValue(BObject service, String key) {
         BMap<BString, Object> serviceConfig = getServiceConfig(service);
@@ -148,7 +148,7 @@ public class ASBUtils {
         BMap<BString, Object> serviceConfig = (BMap<BString, Object>) serviceType
                 .getAnnotation(StringUtils.fromString(ModuleUtils.getModule().getOrg() + ORG_NAME_SEPARATOR
                         + ModuleUtils.getModule().getName() + VERSION_SEPARATOR
-                        + ModuleUtils.getModule().getVersion() + ":"
+                        + ModuleUtils.getModule().getMajorVersion() + ":"
                         + ASBConstants.SERVICE_CONFIG));
         return serviceConfig;
     }

--- a/native/asb/src/main/java/io/ballerinax/asb/util/ASBUtils.java
+++ b/native/asb/src/main/java/io/ballerinax/asb/util/ASBUtils.java
@@ -23,10 +23,15 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ErrorType;
+import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.ORG_NAME_SEPARATOR;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.VERSION_SEPARATOR;
 
 public class ASBUtils {
 
@@ -89,4 +94,64 @@ public class ASBUtils {
         return ErrorCreator.createError(errorType, StringUtils.fromString(message + " error from " + errorFromClass), er,
         map);
     }
+
+    /**
+     * Checks if PEEK LOCK mode is enabled for listening for messages.
+     * 
+     * @param service Service instance having configuration 
+     * @return true if enabled
+     */
+    public static boolean isPeekLockModeEnabled(BObject service) {
+        BMap<BString, Object> serviceConfig = getServiceConfig(service);
+        boolean peekLockEnabled = false;
+        if (serviceConfig != null && serviceConfig.containsKey(ASBConstants.PEEK_LOCK_ENABLE_CONFIG_KEY)) {
+            peekLockEnabled = serviceConfig.getBooleanValue(ASBConstants.PEEK_LOCK_ENABLE_CONFIG_KEY);
+        }
+        return peekLockEnabled;
+    }
+
+    /**
+     * Obtain string value of a service level configuration. 
+     * 
+     * @param service Service instance
+     * @param key Key of the configuration
+     * @return String value of the given config key, or null if not found
+     */
+    public static String getServiceConfigStringValue(BObject service, String key) {
+        BMap<BString, Object> serviceConfig = getServiceConfig(service);
+        if (serviceConfig != null && serviceConfig.containsKey(StringUtils.fromString(key))) {
+            return serviceConfig.getStringValue(StringUtils.fromString(key)).getValue();
+        } else {
+            return ASBConstants.EMPTY_STRING;
+        }
+    }
+
+    /**
+     * Obtain numeric value of a service level configuration.
+     * 
+     * @param service Service instance
+     * @param key     Key of the configuration
+     * @return Integer value of the given config key, or null if not found
+     */
+    public static Integer getServiceConfigSNumericValue(BObject service, String key, int defaultValue) {
+        BMap<BString, Object> serviceConfig = getServiceConfig(service);
+        if (serviceConfig != null && serviceConfig.containsKey(StringUtils.fromString(key))) {
+            return serviceConfig.getIntValue(StringUtils.fromString(key)).intValue();
+        } else {
+            return defaultValue;
+        }
+    }
+    
+    private static BMap<BString, Object> getServiceConfig(BObject service) {
+        ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(service.getType());
+        @SuppressWarnings("unchecked")
+        BMap<BString, Object> serviceConfig = (BMap<BString, Object>) serviceType
+                .getAnnotation(StringUtils.fromString(ModuleUtils.getModule().getOrg() + ORG_NAME_SEPARATOR
+                        + ModuleUtils.getModule().getName() + VERSION_SEPARATOR
+                        + ModuleUtils.getModule().getVersion() + ":"
+                        + ASBConstants.SERVICE_CONFIG));
+        return serviceConfig;
+    }
+
+
 }


### PR DESCRIPTION
## Purpose

Multiple services should be able to attach to the Azure Service Bus listener endpoint. The required configurations should be read from the service level annotations. 

Related issue: https://github.com/wso2-enterprise/choreo/issues/19011

## Goals

Refactor listener giving $Subject

## Approach

There is a way to share same connection between underlying ASB processor clients. Please refer 
https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme?view=azure-java-stable#sharing-of-connection-between-clients

Listener endpoint will create shared sharedConnectionBuilder. 
When attaching services, it will create processor clients using the sharedConnectionBuilder. 

## User stories

Listen to two different queues, using same listener endpoint. 

## Release note
> Add multi service attachment support for ASB listener

## Documentation
Please refer to module.md updates. 


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

