### PR TITLE
Bump the asb version to `1.3.0`

### DIFF
--- a/asyncapi/asb/Ballerina.toml
+++ b/asyncapi/asb/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "trigger.asb"
-version = "1.2.0"
+version = "1.3.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
@@ -13,9 +13,9 @@ distribution = "2201.11.0"
 observabilityIncluded = true
 
 [[platform.java21.dependency]]
-path = "../../native/asb/build/libs/asb-1.2.0.jar"
+path = "../../native/asb/build/libs/asb-1.3.0.jar"
 groupId = "org.ballerinax"
 artifactId = "asb"
 module = "asb" 
-version = "1.2.0"
+version = "1.3.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ tasks.register('codeBuild') {
             println "Task: Pushing triggers to local..."
             for (String path : ballerinaPackages) {
                 // Temporarily disable salesforce.trigger and asb.trigger build as it has yet to migrate to U11
-                if (path.contains("salesforce") || path.contains("asb")) {
+                if (path.contains("salesforce")) {
                     continue;
                 }
                 try {
@@ -107,7 +107,7 @@ tasks.register('releaseTrigger') {
             println "Task: Pushing triggers to Ballerina Central..."
             for (String path : ballerinaPackages) {
                 // Temporarily disable salesforce.trigger and asb.trigger release as it has yet to migrate to U11
-                if (path.contains("salesforce") || path.contains("asb")) {
+                if (path.contains("salesforce")) {
                     continue;
                 }
                 try {

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ tasks.register('codeBuild') {
         println "Task: Building triggers..."
         for (String path : ballerinaPackages) {
             // Temporarily disable salesforce.trigger and asb.trigger build as it has yet to migrate to U11
-            if (path.contains("salesforce") || path.contains("asb")) {
+            if (path.contains("salesforce")) {
                 continue;
             }
             if (!(path.contains("asgardeo") || path.contains("hubspot") || path.contains("quickbooks"))) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ sfdc_trigger_version=0.10.0
 
 // Azure service bus trigger
 asb_trigger_group=io.ballerinax.asb
-asb_trigger_version=1.2.0
+asb_trigger_version=1.3.0
 asb_sdk_version=7.13.1
 
 // Asgardeo trigger


### PR DESCRIPTION
## Purpose
> The `ballerinax/trigger.asb` hasn't been released to the Ballerina central with the update 11 even though the workflow has already been run. This fix will bump the version of the `trigger.asb` module into the next minor version