### PR TITLE
docs(hubspot): fix Hubspot mis-casing in trigger README

### DIFF
--- a/asyncapi/hubspot/README.md
+++ b/asyncapi/hubspot/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The [Ballerina](https://ballerina.io/) listener for Hubspot allows you to listen to the following events in a HubSpot account, grouped by the CRM object they relate to.
+The [Ballerina](https://ballerina.io/) listener for HubSpot allows you to listen to the following events in a HubSpot account, grouped by the CRM object they relate to.
 
 * **Company** (`CompanyService`): `onCompanyCreation`, `onCompanyDeletion`, `onCompanyPropertychange`, `onCompanyAssociationchange`, `onCompanyMerge`, `onCompanyRestore`
 * **Contact** (`ContactService`): `onContactCreation`, `onContactDeletion`, `onContactPropertychange`, `onContactAssociationchange`, `onContactMerge`, `onContactRestore`, `onContactPrivacydeletion`


### PR DESCRIPTION
## Purpose

Fix one README brand-name mis-casing in the HubSpot trigger documentation. Identified during the HubSpot connector audit.

## Changes

- `asyncapi/hubspot/README.md` line 3: replace standalone `Hubspot` with `HubSpot` in the listener description sentence. All other HubSpot brand references in the file are already correctly cased.

Scoped strictly to `asyncapi/hubspot/` — no other trigger directory in this mono repo is touched. No code, no build, no other files.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog — N/A (docs-only)
- [ ] Added tests — N/A (docs-only)
- [x] Checked native-image compatibility — N/A (no code change)

Refs ballerina-platform/ballerina-library#8823