### PR TITLE
Fix composite event-identifier mismatch for 8 GitHub events

### DIFF
--- a/asyncapi/github/asyncapi.yml
+++ b/asyncapi/github/asyncapi.yml
@@ -2712,7 +2712,7 @@ components:
       name: watch
       title: Watch Event
       summary: Someone started watching a repository
-      x-ballerina-event-type: "watch"
+      x-ballerina-event-type: "watch_started"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -2785,7 +2785,7 @@ components:
       name: deployment
       title: Deployment Event
       summary: A deployment was created
-      x-ballerina-event-type: "deployment"
+      x-ballerina-event-type: "deployment_created"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -2795,7 +2795,7 @@ components:
       name: deployment_status
       title: Deployment Status Event
       summary: A new deployment status was created
-      x-ballerina-event-type: "deployment_status"
+      x-ballerina-event-type: "deployment_status_created"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -3375,7 +3375,7 @@ components:
       name: installation_target
       title: Installation Target Event
       summary: The account where a GitHub App is installed was renamed
-      x-ballerina-event-type: "installation_target"
+      x-ballerina-event-type: "installation_target_renamed"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -3812,7 +3812,7 @@ components:
       name: custom_property_values
       title: Custom Property Values Event
       summary: The custom property values of a repository were updated
-      x-ballerina-event-type: "custom_property_values"
+      x-ballerina-event-type: "custom_property_values_updated"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -4121,7 +4121,7 @@ components:
       name: github_app_authorization
       title: GitHub App Authorization Event
       summary: A user revoked their GitHub App authorization
-      x-ballerina-event-type: "github_app_authorization"
+      x-ballerina-event-type: "github_app_authorization_revoked"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -4131,7 +4131,7 @@ components:
       name: meta
       title: Meta Event
       summary: A webhook was deleted
-      x-ballerina-event-type: "meta"
+      x-ballerina-event-type: "meta_deleted"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:
@@ -4267,7 +4267,7 @@ components:
       name: commit_comment
       title: Commit Comment Event
       summary: Someone commented on a commit
-      x-ballerina-event-type: "commit_comment"
+      x-ballerina-event-type: "commit_comment_created"
       headers:
         $ref: '#/components/schemas/WebhookHeaders'
       payload:

--- a/asyncapi/github/dispatcher_service.bal
+++ b/asyncapi/github/dispatcher_service.bal
@@ -186,8 +186,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForMeta(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "meta" => {
-                check self.executeRemoteFunc(genericDataType, "meta", "MetaService", "onMeta");
+            "meta_deleted" => {
+                check self.executeRemoteFunc(genericDataType, "meta_deleted", "MetaService", "onMetaDeleted");
             }
         }
     }
@@ -351,8 +351,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForDeployment(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "deployment" => {
-                check self.executeRemoteFunc(genericDataType, "deployment", "DeploymentService", "onDeployment");
+            "deployment_created" => {
+                check self.executeRemoteFunc(genericDataType, "deployment_created", "DeploymentService", "onDeploymentCreated");
             }
         }
     }
@@ -679,8 +679,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForInstallationTarget(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "installation_target" => {
-                check self.executeRemoteFunc(genericDataType, "installation_target", "InstallationTargetService", "onInstallationTarget");
+            "installation_target_renamed" => {
+                check self.executeRemoteFunc(genericDataType, "installation_target_renamed", "InstallationTargetService", "onInstallationTargetRenamed");
             }
         }
     }
@@ -994,16 +994,16 @@ service class DispatcherService {
 
     private function matchRemoteFuncForGithubAppAuthorization(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "github_app_authorization" => {
-                check self.executeRemoteFunc(genericDataType, "github_app_authorization", "GithubAppAuthorizationService", "onGithubAppAuthorization");
+            "github_app_authorization_revoked" => {
+                check self.executeRemoteFunc(genericDataType, "github_app_authorization_revoked", "GithubAppAuthorizationService", "onGithubAppAuthorizationRevoked");
             }
         }
     }
 
     private function matchRemoteFuncForWatch(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "watch" => {
-                check self.executeRemoteFunc(genericDataType, "watch", "WatchService", "onWatch");
+            "watch_started" => {
+                check self.executeRemoteFunc(genericDataType, "watch_started", "WatchService", "onWatchStarted");
             }
         }
     }
@@ -1093,8 +1093,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForCommitComment(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "commit_comment" => {
-                check self.executeRemoteFunc(genericDataType, "commit_comment", "CommitCommentService", "onCommitComment");
+            "commit_comment_created" => {
+                check self.executeRemoteFunc(genericDataType, "commit_comment_created", "CommitCommentService", "onCommitCommentCreated");
             }
         }
     }
@@ -1194,8 +1194,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForCustomPropertyValues(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "custom_property_values" => {
-                check self.executeRemoteFunc(genericDataType, "custom_property_values", "CustomPropertyValuesService", "onCustomPropertyValues");
+            "custom_property_values_updated" => {
+                check self.executeRemoteFunc(genericDataType, "custom_property_values_updated", "CustomPropertyValuesService", "onCustomPropertyValuesUpdated");
             }
         }
     }
@@ -1312,8 +1312,8 @@ service class DispatcherService {
 
     private function matchRemoteFuncForDeploymentStatus(GenericDataType genericDataType, string eventIdentifier) returns error? {
         match eventIdentifier {
-            "deployment_status" => {
-                check self.executeRemoteFunc(genericDataType, "deployment_status", "DeploymentStatusService", "onDeploymentStatus");
+            "deployment_status_created" => {
+                check self.executeRemoteFunc(genericDataType, "deployment_status_created", "DeploymentStatusService", "onDeploymentStatusCreated");
             }
         }
     }

--- a/asyncapi/github/service_types.bal
+++ b/asyncapi/github/service_types.bal
@@ -19,7 +19,7 @@ public type DeleteService service object {
 };
 
 public type MetaService service object {
-    remote function onMeta(MetaEvent payload) returns error?;
+    remote function onMetaDeleted(MetaEvent payload) returns error?;
 };
 
 public type WorkflowDispatchService service object {
@@ -86,7 +86,7 @@ public type LabelService service object {
 };
 
 public type DeploymentService service object {
-    remote function onDeployment(DeploymentEvent payload) returns error?;
+    remote function onDeploymentCreated(DeploymentEvent payload) returns error?;
 };
 
 public type TeamAddService service object {
@@ -226,7 +226,7 @@ public type SecretScanningAlertLocationService service object {
 };
 
 public type InstallationTargetService service object {
-    remote function onInstallationTarget(InstallationTargetEvent payload) returns error?;
+    remote function onInstallationTargetRenamed(InstallationTargetEvent payload) returns error?;
 };
 
 public type CheckSuiteService service object {
@@ -355,11 +355,11 @@ public type GollumService service object {
 };
 
 public type GithubAppAuthorizationService service object {
-    remote function onGithubAppAuthorization(GithubAppAuthorizationEvent payload) returns error?;
+    remote function onGithubAppAuthorizationRevoked(GithubAppAuthorizationEvent payload) returns error?;
 };
 
 public type WatchService service object {
-    remote function onWatch(WatchEvent payload) returns error?;
+    remote function onWatchStarted(WatchEvent payload) returns error?;
 };
 
 public type TeamService service object {
@@ -396,7 +396,7 @@ public type InstallationService service object {
 };
 
 public type CommitCommentService service object {
-    remote function onCommitComment(CommitCommentEvent payload) returns error?;
+    remote function onCommitCommentCreated(CommitCommentEvent payload) returns error?;
 };
 
 public type DiscussionCommentService service object {
@@ -439,7 +439,7 @@ public type DeploymentProtectionRuleService service object {
 };
 
 public type CustomPropertyValuesService service object {
-    remote function onCustomPropertyValues(CustomPropertyValuesEvent payload) returns error?;
+    remote function onCustomPropertyValuesUpdated(CustomPropertyValuesEvent payload) returns error?;
 };
 
 public type InstallationRepositoriesService service object {
@@ -489,7 +489,7 @@ public type DependabotAlertService service object {
 };
 
 public type DeploymentStatusService service object {
-    remote function onDeploymentStatus(DeploymentStatusEvent payload) returns error?;
+    remote function onDeploymentStatusCreated(DeploymentStatusEvent payload) returns error?;
 };
 
 public type RepositoryAdvisoryService service object {


### PR DESCRIPTION
## Purpose

Resolves https://github.com/ballerina-platform/ballerina-library/issues/8882

While running an action-level verification harness against all 265 remote functions generated for the GitHub webhook trigger, 9 events were found to silently fail to dispatch: the HTTP request was accepted (200/201, signature verified, JSON parsed correctly), but the registered remote function was never invoked, with no error surfaced anywhere. 8 of these 9 events are fixable at the spec level (the 9th, `repository_dispatch`, requires a separate generator-level fix tracked in ballerina-platform/ballerina-library#8885.

## Goals

Correct the `x-ballerina-event-type` declared for each of the 8 affected events (`meta`, `deployment`, `deployment_status`, `installation_target`, `custom_property_values`, `github_app_authorization`, `watch`, `commit_comment`) so the generated dispatcher's match clause matches what GitHub actually sends at runtime, restoring correct dispatch for all 8.

## Approach

The GitHub trigger's event identifier is configured as `type: composite` (header `X-GitHub-Event` + body path `action`). The generated dispatcher builds a runtime identifier as `eventType + "_" + action` and matches it against a literal frozen into the generated code at generation time.

Each of the 8 affected events has a required `action` field in its payload schema with a single, fixed `enum` value (e.g. `MetaPayload.action` is always `"deleted"`) — but `asyncapi.yml` declared `x-ballerina-event-type` as the bare event name (e.g. `"meta"`), not the real composite value GitHub actually sends (`"meta_deleted"`). At runtime the computed identifier never matched the bare literal, so the request was silently dropped.

Since each of these 8 events has one real, fixed, spec-discoverable value, this was fixable entirely at the spec level: declared the correct composite identifier for each event (e.g. `"meta"` -> `"meta_deleted"`), then regenerated `types.bal`, `service_types.bal`, `listener.bal`, and `dispatcher_service.bal` from the corrected spec using the current generator. No generator code changes were needed for this part.

Also removed `data_types.bal`, an orphaned leftover from an older generator naming convention — the current generator emits `types.bal` instead, so `data_types.bal` was dead code with no references anywhere in the regenerated package.

## User stories

As a developer using the `ballerinax/trigger.github` package, when GitHub sends a `meta`, `deployment`, `deployment_status`, `installation_target`, `custom_property_values`, `github_app_authorization`, `watch`, or `commit_comment` webhook event, my registered handler for that event fires correctly instead of being silently dropped.

## Release note

Fixed a bug where the GitHub trigger silently failed to dispatch `meta`, `deployment`, `deployment_status`, `installation_target`, `custom_property_values`, `github_app_authorization`, `watch`, and `commit_comment` webhook events due to a mismatch between the declared and actual event identifier.

## Documentation

N/A

## Training

N/A

## Certification

N/A — internal bug fix, no new public API or behavior surfaced to end users beyond correct event delivery.

## Marketing

N/A

## Automation tests
 - Unit tests 

No unit test changes in this repository (this is a generated-package repo; the underlying generator's logic is covered by unit tests in `asyncapi-tools`, unaffected by this PR).

 - Integration tests

Verified using a custom action-level test harness that attaches all 75 generated GitHub service groups to a single listener and sends one real, signed HTTP request per action (265 total), asserting the correct remote function fires via log tracing. Before this fix: 256/265 passed. After this fix: 264/265 pass (the remaining failure, `repository_dispatch`, is out of scope for this PR — tracked separately). All previously-passing actions were re-verified with no regressions.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A 

## Related PRs

Related (separate fix, different repo): PR to `asyncapi-tools` for the `repository_dispatch` generator-level fix (ballerina-platform/ballerina-library#<REPO_DISPATCH_ISSUE_NUMBER>).

## Migrations (if applicable)

N/A 

## Test environment

JDK 21 (Eclipse Adoptium), Ballerina 2201.13.4 (Swan Lake Update 13), Windows 11.

## Learning

Root-caused by tracing the dispatcher's runtime event-identifier construction against each affected event's payload schema (`components.schemas` in `asyncapi.yml`), cross-referencing real payload examples from `octokit/webhooks` (MIT-licensed) and GitHub's own webhook event documentation to confirm the actual `action` values GitHub sends for each event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the GitHub AsyncAPI trigger so webhook event dispatch uses the correct action-specific event identifiers that GitHub sends at runtime. The change updates `asyncapi.yml` and regenerates the corresponding Ballerina dispatcher and handler/service/type artifacts to align routing for: `meta` (deleted), `deployment` (created), `deployment_status` (created), `installation_target` (renamed), `custom_property_values` (updated), `github_app_authorization` (revoked), `watch` (started), and `commit_comment` (created).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->