### PR TITLE
Fix webhook acknowledgment responses returning HTTP 201 instead of 200 across 10 trigger packages

### DIFF
--- a/asyncapi/aayu.mftg.as2/dispatcher_service.bal
+++ b/asyncapi/aayu.mftg.as2/dispatcher_service.bal
@@ -42,7 +42,9 @@ service class DispatcherService {
         json payload = check request.getJsonPayload();
         GenericDataType genericDataType = check payload.cloneWithType(GenericDataType);
         check self.matchRemoteFunc(genericDataType);
-        check caller->respond(http:STATUS_OK);
+        http:Response ackRes = new;
+        ackRes.statusCode = http:STATUS_OK;
+        check caller->respond(ackRes);
     }
 
     private function matchRemoteFunc(GenericDataType genericDataType) returns error? {

--- a/asyncapi/github/dispatcher_service.bal
+++ b/asyncapi/github/dispatcher_service.bal
@@ -59,7 +59,9 @@ service class DispatcherService {
         }
         GenericDataType genericDataType = check payload.cloneWithType(GenericDataType);
         check self.matchRemoteFunc(genericDataType, eventIdentifier, eventType);
-        check caller->respond(http:STATUS_OK);
+        http:Response ackRes = new;
+        ackRes.statusCode = http:STATUS_OK;
+        check caller->respond(ackRes);
     }
 
     private function verifyWebhookSignature(http:Request request, string webhookSecret) returns error? {

--- a/asyncapi/google.calendar/dispatcher_service.bal
+++ b/asyncapi/google.calendar/dispatcher_service.bal
@@ -79,7 +79,9 @@ service class DispatcherService {
                 check caller->respond(res);
             }
         } else {
-            check caller->respond(http:STATUS_OK);
+            http:Response invalidRequestRes = new;
+            invalidRequestRes.statusCode = http:STATUS_OK;
+            check caller->respond(invalidRequestRes);
         }
     }
 

--- a/asyncapi/google.drive/dispatcher_service.bal
+++ b/asyncapi/google.drive/dispatcher_service.bal
@@ -111,7 +111,9 @@ service class DispatcherService {
                     check self.mapEvents(<@untainted>item, <@untainted>self.driveConfig);
                 }
             }
-            check caller->respond(http:STATUS_OK);
+            http:Response ackRes = new;
+            ackRes.statusCode = http:STATUS_OK;
+            check caller->respond(ackRes);
         }
     }
 

--- a/asyncapi/google.mail/dispatcher_service.bal
+++ b/asyncapi/google.mail/dispatcher_service.bal
@@ -104,13 +104,19 @@ service class DispatcherService {
                 log:printDebug(NEXT_HISTORY_ID + lastHistoryId);
             }
             if historyFetchFailed {
-                check caller->respond(http:STATUS_INTERNAL_SERVER_ERROR);
+                http:Response errorRes = new;
+                errorRes.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                check caller->respond(errorRes);
             } else {
-                check caller->respond(http:STATUS_OK);
+                http:Response ackRes = new;
+                ackRes.statusCode = http:STATUS_OK;
+                check caller->respond(ackRes);
             }
         } else {
             log:printWarn(WARN_UNKNOWN_PUSH_NOTIFICATION + incomingSubscription);
-            check caller->respond(http:STATUS_OK);
+            http:Response unknownSubscriptionRes = new;
+            unknownSubscriptionRes.statusCode = http:STATUS_OK;
+            check caller->respond(unknownSubscriptionRes);
         }
     }
 

--- a/asyncapi/google.sheets/dispatcher_service.bal
+++ b/asyncapi/google.sheets/dispatcher_service.bal
@@ -54,7 +54,9 @@ service class DispatcherService {
         }
         GenericDataType genericDataType = check payload.cloneWithType(GenericDataType);
         check self.matchRemoteFunc(genericDataType);
-        check caller->respond(http:STATUS_OK);
+        http:Response ackRes = new;
+        ackRes.statusCode = http:STATUS_OK;
+        check caller->respond(ackRes);
     }
 
     private function matchRemoteFunc(GenericDataType genericDataType) returns error? {

--- a/asyncapi/hubspot/dispatcher_service.bal
+++ b/asyncapi/hubspot/dispatcher_service.bal
@@ -72,7 +72,8 @@ service class DispatcherService {
             }
         }
 
-        check caller->respond(http:STATUS_OK);
+        response.statusCode = http:STATUS_OK;
+        check caller->respond(response);
         return;
     }
 

--- a/asyncapi/quickbooks/dispatcher_service.bal
+++ b/asyncapi/quickbooks/dispatcher_service.bal
@@ -65,7 +65,9 @@ service class DispatcherService {
 
         CommonResponseType genericDataType = check payload.cloneWithType(CommonResponseType);
         check self.matchRemoteFunc(genericDataType);
-        return caller->respond(http:STATUS_OK);
+        http:Response ackRes = new;
+        ackRes.statusCode = http:STATUS_OK;
+        return caller->respond(ackRes);
     }
 
     private function matchRemoteFunc(CommonResponseType genericDataType) returns error? {

--- a/asyncapi/shopify/dispatcher_service.bal
+++ b/asyncapi/shopify/dispatcher_service.bal
@@ -64,7 +64,9 @@ service class DispatcherService {
             }
         }    
         check self.matchRemoteFunc(payload, eventName);
-        return caller->respond(http:STATUS_OK);
+        http:Response ackRes = new;
+        ackRes.statusCode = http:STATUS_OK;
+        return caller->respond(ackRes);
     }
 
     private function matchRemoteFunc(json payload, string eventName) returns error? {

--- a/asyncapi/slack/dispatcher_service.bal
+++ b/asyncapi/slack/dispatcher_service.bal
@@ -42,7 +42,9 @@ service class DispatcherService {
         } else {
             GenericDataType genericDataType = check payload.cloneWithType(GenericDataType);
             check self.matchRemoteFunc(genericDataType);
-            check caller->respond(http:STATUS_OK);
+            http:Response ackRes = new;
+            ackRes.statusCode = http:STATUS_OK;
+            check caller->respond(ackRes);
         }
     }
 


### PR DESCRIPTION
## Purpose
Multiple trigger dispatchers acknowledge webhook requests with `check caller->respond(http:STATUS_OK);` (or, in one case, `http:STATUS_INTERNAL_SERVER_ERROR`). Passing a bare status-code constant like this gets treated by Ballerina as a JSON response body, not a status code - combined with `ballerina/http`'s own default of 201 Created for POST responses built this way, every one of these acknowledgment/error paths was returning the wrong HTTP status. Found in 10 of the 15 trigger packages in this repo, 12 occurrences total.

Resolves: https://github.com/ballerina-platform/ballerina-library/issues/8920

## Goals
Make every affected acknowledgment/error response return the status code that was actually intended (200 for successful acknowledgments, 500 for the one real error-reporting case in google.mail), instead of silently defaulting to 201 regardless of what happened.

## Approach
Replaced each bare `check caller->respond(http:STATUS_X);` (or `return caller->respond(http:STATUS_X);`) call with an explicitly constructed `http:Response`, setting `statusCode` directly before responding - the same pattern already used correctly elsewhere in these same files. Applied identically across all 10 affected files: `aayu.mftg.as2`, `github`, `google.calendar`, `google.drive`, `google.mail` (3 occurrences, including the `STATUS_INTERNAL_SERVER_ERROR` case), `google.sheets`, `hubspot`, `quickbooks`, `shopify`, `slack`.

## User stories
As an operator running an integration on any of these triggers, I want the HTTP response my webhook provider receives to accurately reflect what happened (success vs failure), so that provider-side retry logic, delivery-confirmation checks, and any monitoring built on response status codes behave correctly instead of seeing every request - including real failures - reported as 201 Created.

## Release note
Fixed webhook acknowledgment and error responses returning HTTP 201 Created instead of the intended status (200 OK, or 500 Internal Server Error for google.mail's history-fetch-failure case) across 10 trigger packages: aayu.mftg.as2, github, google.calendar, google.drive, google.mail, google.sheets, hubspot, quickbooks, shopify, slack.

## Documentation
N/A 

## Training
N/A 

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   N/A
 - Integration tests
   Verified directly against two independently-built dispatch-verification harnesses (`testing-artifacts/github` and `testing-artifacts/google.calendar` in the asyncapi-tools repo). For github: sent a real signed webhook POST (delete event) and confirmed the response is now `200 OK` with an empty body (previously `201` with a stray `200` body), with dispatch still firing correctly (`FIRED::DeleteService::onDelete`). For google.calendar: confirmed the invalid-request rejection path now returns `200` (previously `201`), with all 3 dispatch scenarios re-verified afterward with no regressions. The remaining 8 packages were verified via `bal build` (all compile cleanly) plus direct code review confirming the identical fix pattern was applied correctly at each call site.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A 

## Migrations (if applicable)
N/A 

## Test environment
JDK 21 (Temurin 21.0.2), Windows 11, Ballerina 2201.13.4 (Swan Lake Update 13). 


