### PR TITLE
Fix google.mail: new-email events never fire because Inbox check tries to read labelID too early

### DIFF
--- a/asyncapi/google.mail/dispatcher_service.bal
+++ b/asyncapi/google.mail/dispatcher_service.bal
@@ -126,17 +126,7 @@ service class DispatcherService {
         if messagesAdded is gmail:HistoryMessageAdded[] {
             if messagesAdded.length() > 0 {
                 foreach gmail:HistoryMessageAdded newMessage in messagesAdded {
-                    gmail:Message? msg = newMessage.message;
-                    if msg is gmail:Message && msg.labelIds is string[] {
-                        foreach var labelId in <string[]>msg.labelIds {
-                            match labelId {
-                                INBOX => {
-                                    check self.dispatchNewMessage(newMessage);
-                                    check self.dispatchNewThread(newMessage);
-                                }
-                            }
-                        }
-                    }
+                    check self.dispatchNewMessage(newMessage);
                 }
             }
         }
@@ -166,10 +156,19 @@ service class DispatcherService {
             return;
         }
         gmail:Message message = check readMessage(self.gmailConfig, <@untainted>msg.id);
-        check self.executeRemoteFunc(message, "newEmail", "GmailService", "onNewEmail");
-        MessageBodyPart[] msgAttachments = convertToMessageBodyParts(getAttachments(message));
-        if (msgAttachments.length() > 0) {
-            check self.dispatchNewAttachment(msgAttachments, message);
+        if message.labelIds is string[] {
+            foreach var labelId in <string[]>message.labelIds {
+                match labelId {
+                    INBOX => {
+                        check self.executeRemoteFunc(message, "newEmail", "GmailService", "onNewEmail");
+                        MessageBodyPart[] msgAttachments = convertToMessageBodyParts(getAttachments(message));
+                        if (msgAttachments.length() > 0) {
+                            check self.dispatchNewAttachment(msgAttachments, message);
+                        }
+                        check self.dispatchNewThread(newMessage);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
`onNewEmail`, `onNewThread`, and `onNewAttachment` never fire in production, for any new email, under any circumstances - found and root-caused via a mock-based dispatch-verification harness (`asyncapi-tools`, `testing-artifacts/google.mail/`, see `SUMMARY.md` there for the full scenario matrix). Resolves https://github.com/ballerina-platform/ballerina-library/issues/8981.

## Goals
Make `onNewEmail`, `onNewThread`, and `onNewAttachment` fire correctly for every new email arriving in the watched inbox, without any change on the connector side.

## Approach
`dispatch()` gated all new-message handling on `msg.labelIds` read from the embedded message inside `HistoryMessageAdded` - but `ballerinax/googleapis.gmail` 4.2.0's `convertOASListHistoryResponseToListHistoryResponse` always rebuilds that embedded message with only `id`/`threadId`, so `labelIds` is never populated there. The gate was structurally always false.

Moved the Inbox check into `dispatchNewMessage()`, after `readMessage()` fetches the full message - which does carry `labelIds`. `dispatch()` now calls `dispatchNewMessage()` unconditionally per `messagesAdded` entry, matching how `labelsAdded`/`labelsRemoved` are already handled (no pre-filter). `dispatchNewThread()` moves inside the Inbox-check branch too, since it was previously only reachable alongside the same dead check.

Single-file change (`dispatcher_service.bal`), no connector-side dependency.

## User stories
As a `google.mail` trigger user, I should be notified via `onNewEmail` whenever a new email arrives
in my watched inbox - not silently never.

## Release note
Fix: `google.mail` trigger's `onNewEmail`/`onNewThread`/`onNewAttachment` now fire correctly for
new emails (previously never fired due to a stale Inbox check reading data the connector doesn't
populate at that stage).

## Documentation
N/A 

## Automation tests
- Unit tests: N/A (no existing unit test suite for this package's dispatch logic).
- Integration tests: verified via a mock-based dispatch-verification harness (`asyncapi-tools`, `testing-artifacts/google.mail/`) covering all 7 remote functions across 7 scenarios against a local mock Gmail/Pub/Sub API, using the exact connector version (4.2.0) pinned in this package's `Dependencies.toml`. Before this fix: 6/11 checks passing (3 of 7 functions dead). After: 11/11 passing, no regressions.

## Security checks
- Followed secure coding standards: yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Test environment
Windows 11, Ballerina Swan Lake 2201.13.x, `ballerinax/googleapis.gmail` 4.2.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `google.mail` new-message event dispatching.
- Moved the Inbox label check to occur after the full message is fetched.
- Enabled `onNewEmail`, `onNewThread`, and `onNewAttachment` events for new Inbox messages.
- Improved mock harness results from 6/11 to 11/11 checks passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->