### PR TITLE
Fix google.mail: persist the history checkpoint per-item, stop at the first dispatch failure

### DIFF
--- a/asyncapi/google.mail/constants.bal
+++ b/asyncapi/google.mail/constants.bal
@@ -100,6 +100,7 @@ const string INFO_RETRY_SCHEDULE = "Retrying to schedule watch renewal. Attempt 
 const string ERR_WATCH_MAILBOX = "Unable to watch mailbox.";
 const string ERR_SCHEDULE = "Unable to schedule watch renewal.";
 const string ERR_HISTORY_LIST = "Unable to schedule watch renewal.";
+const string ERR_DISPATCH_FAILED = "Unable to dispatch history item.";
 
 public enum Encoding {
     ENCODING_UNSPECIFIED,

--- a/asyncapi/google.mail/dispatcher_service.bal
+++ b/asyncapi/google.mail/dispatcher_service.bal
@@ -99,16 +99,20 @@ service class DispatcherService {
                     if dispatchFailed {
                         break;
                     }
-                    // Prefer the mailbox-level historyId from the response as the next cursor
-                    string? responseHistoryId = historyResponse.historyId;
-                    if responseHistoryId is string {
-                        lastHistoryId = responseHistoryId;
-                        self.setStartHistoryId(lastHistoryId);
-                    }
                     string? nextToken = historyResponse.nextPageToken;
                     if nextToken is string {
+                        // More pages still to come - don't persist this page's own historyId yet.
+                        // If a later page then fails, that would jump the checkpoint ahead of
+                        // content this page's response cursor doesn't actually cover yet.
                         pageToken = nextToken;
                     } else {
+                        // Last page, and everything up to here succeeded - now it's safe to prefer
+                        // the mailbox-level historyId from the response as the next cursor.
+                        string? responseHistoryId = historyResponse.historyId;
+                        if responseHistoryId is string {
+                            lastHistoryId = responseHistoryId;
+                            self.setStartHistoryId(lastHistoryId);
+                        }
                         break;
                     }
                 } else {

--- a/asyncapi/google.mail/dispatcher_service.bal
+++ b/asyncapi/google.mail/dispatcher_service.bal
@@ -67,6 +67,7 @@ service class DispatcherService {
         if (self.subscriptionResource === incomingSubscription) {
             string? pageToken = ();
             boolean historyFetchFailed = false;
+            boolean dispatchFailed = false;
             string startId = self.getStartHistoryId();
             string lastHistoryId = startId;
             while true {
@@ -75,17 +76,34 @@ service class DispatcherService {
                     gmail:History[]? historyList = historyResponse.history;
                     if historyList is gmail:History[] {
                         foreach gmail:History historyItem in historyList {
-                            check self.dispatch(historyItem);
+                            error? dispatchResult = self.dispatch(historyItem);
+                            if dispatchResult is error {
+                                // Stop here - don't advance the checkpoint past this item (it must
+                                // be retried, not silently skipped), and don't attempt later items
+                                // in this batch either, so they can't get checkpointed ahead of a
+                                // still-unresolved failure earlier in the same batch.
+                                log:printError(ERR_DISPATCH_FAILED, 'error = dispatchResult);
+                                dispatchFailed = true;
+                                break;
+                            }
+                            // Persist after every successful item, not once at the end of the whole
+                            // batch - a later item's dispatch failure must not erase the checkpoint
+                            // for items that already succeeded before it.
                             string? itemId = historyItem.id;
                             if itemId is string {
                                 lastHistoryId = itemId;
+                                self.setStartHistoryId(lastHistoryId);
                             }
                         }
+                    }
+                    if dispatchFailed {
+                        break;
                     }
                     // Prefer the mailbox-level historyId from the response as the next cursor
                     string? responseHistoryId = historyResponse.historyId;
                     if responseHistoryId is string {
                         lastHistoryId = responseHistoryId;
+                        self.setStartHistoryId(lastHistoryId);
                     }
                     string? nextToken = historyResponse.nextPageToken;
                     if nextToken is string {
@@ -99,13 +117,14 @@ service class DispatcherService {
                     break;
                 }
             }
-            if !historyFetchFailed {
-                self.setStartHistoryId(lastHistoryId);
-                log:printDebug(NEXT_HISTORY_ID + lastHistoryId);
-            }
+            log:printDebug(NEXT_HISTORY_ID + lastHistoryId);
             if historyFetchFailed {
                 check caller->respond(http:STATUS_INTERNAL_SERVER_ERROR);
             } else {
+                // Ack 200 even if a dispatch failed partway through - the delivery itself was
+                // received fine. The failed item stays un-checkpointed and gets retried on the
+                // next natural sync; that's a more precise retry than anything Pub/Sub redelivering
+                // the same push notification would give us.
                 check caller->respond(http:STATUS_OK);
             }
         } else {


### PR DESCRIPTION
## Purpose
A mid-batch dispatch failure discarded the checkpoint for the entire batch on retry, including items that had already succeeded and already dispatched to the user's handlers - causing those events to fire a second time. 

Resolves ballerina-platform/ballerina-library#9020.

## Goals
Make a single item's dispatch failure within a history batch stop that batch at that point, without erasing the checkpoint for whatever already succeeded before it, and without letting the failed item (or anything after it) get silently skipped past on the next sync.

## Approach
`dispatcher_service.bal`'s `post` resource function tracked `lastHistoryId` correctly per item in a local variable, but only persisted it once, after the entire loop (across every page) finished with no error. `check self.dispatch(historyItem)` meant a single item's failure aborted the whole resource function immediately, so that final persist never ran, and the checkpoint stayed at whatever it was before the request started.

Now the checkpoint is persisted after each item that dispatches successfully, not once at the end. A dispatch failure stops the batch at that point - later items in the same batch aren't attempted, so nothing can get checkpointed ahead of a still-unresolved failure - and the ack is still 200 either way, since the delivery itself was received fine. The failed item (and anything after it in that batch) is retried on the next natural sync, which is a more precise retry than anything Pub/Sub redelivering the same push notification would give us.

This matches how the two closest vendors doing the same two-hop pattern handle it. Microsoft Graph's official delta-query guidance is to never rebuild from scratch on a transient failure and to persist the cursor only once a page sequence completes cleanly. Dropbox documents its webhook delivery as at-least-once and explicitly recommends idempotent processing for exactly this reason.

## User stories
As a `google.mail` trigger user, if one event in a batch fails to dispatch (for example, my own remote function implementation throwing), I don't want every other event that already succeeded in that same batch to fire a second time once the trigger recovers.

## Release note
Fix: `google.mail`'s history checkpoint is now persisted per successfully-dispatched item instead of once per batch, so a mid-batch dispatch failure no longer causes already-succeeded events to be re-dispatched on retry.

## Documentation
N/A 

## Automation tests
- Unit tests: N/A (no existing unit test suite for this package's dispatch logic).
- Integration tests: verified via a dedicated batch-checkpoint scenario added to the `asyncapi-tools` dispatch-verification harness (https://github.com/ballerina-platform/asyncapi-tools/pull/194) - a two-item history batch where the first item succeeds and the second is made to fail on purpose. Confirms the checkpoint lands on the successful item after a second push, not the pre-batch value (the original bug) and not past the failed item either. Full existing 7-scenario regression suite still 11/11 passing.

## Security checks
- Followed secure coding standards: yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Test environment
Windows 11, Ballerina Swan Lake 2201.13.x, `ballerinax/googleapis.gmail` 4.2.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Persist `google.mail` history checkpoints after each successful dispatch.
- Stop processing at the first dispatch failure and leave the failed and later items eligible for retry.
- Apply the response-level history checkpoint only after the final page succeeds.
- Return HTTP 200 for dispatch failures and retain HTTP 500 responses for history-list failures.
- Add the `ERR_DISPATCH_FAILED` error constant and log dispatch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->